### PR TITLE
JOB-20 : Rafraîchir les Jobs toutes les 5mn

### DIFF
--- a/server/bin/www
+++ b/server/bin/www
@@ -88,3 +88,5 @@ function onListening() {
     : 'port ' + addr.port;
   debug('Listening on ' + bind);
 }
+
+require('../src/schedulers/jobs').run();

--- a/server/src/schedulers/jobs.js
+++ b/server/src/schedulers/jobs.js
@@ -1,0 +1,15 @@
+const cache = require('../infrastructure/cache')
+
+const FIVE_MINUTES = 1000 * 60 * 5
+
+const JobsScheduler = {
+
+  run () {
+    setInterval(() => {
+      cache.del('get_jobs')
+    }, FIVE_MINUTES)
+  }
+
+}
+
+module.exports = JobsScheduler

--- a/server/test/unit/schedulers/jobs.spec.js
+++ b/server/test/unit/schedulers/jobs.spec.js
@@ -1,0 +1,33 @@
+const {expect, sinon} = require('../../test-helper')
+const scheduler = require('../../../src/schedulers/jobs')
+const cache = require('../../../src/infrastructure/cache')
+
+describe('Unit | Schedulers | jobs', () => {
+  let clock
+
+  describe('#run', () => {
+    beforeEach(() => {
+      clock = sinon.useFakeTimers()
+      sinon.stub(cache, 'del')
+    })
+
+    afterEach(() => {
+      clock.restore()
+      cache.del.restore()
+    })
+
+    it('should call #setInterval with good params', () => {
+      // given
+      scheduler.run()
+
+      // when
+      clock.tick(1000 * 60 * 5)
+      clock.tick(1000 * 60 * 5)
+      clock.tick(1000 * 60 * 5)
+
+      // then
+      expect(cache.del).to.have.been.calledThrice
+      expect(cache.del).to.always.have.been.calledWith('get_jobs')
+    })
+  })
+})


### PR DESCRIPTION
Cette PR a pour objet de synchroniser régulièrement les missions à staffer depuis Octopod.

La technique qui a été implémentée respecte une approche naïve : toutes les 5mn on supprime l’entrée du cache qui conserve la liste des activités à staffer.

Cette méthode présente un double intérêt :
- elle est hyper simple à coder / tester
- elle évite de bourriner inutilement Octopod, ex : entre 20h00 et 9h00 du matin

Il y a un inconvénient (mineur) tout de même : toutes les 5 mn on se retrouve avec un « premier payeur » (ttr = 1300ms) d’origine humaine / utilisateur plutôt qu’instruction logicielle.

cf. US #20 