### PR TITLE
JOB-70 : rendre les couleurs compliant WCAG Standard (a11y)

### DIFF
--- a/client/src/components/AppHeader.vue
+++ b/client/src/components/AppHeader.vue
@@ -68,7 +68,7 @@
   }
 
   .logo-link__board {
-    color: #F48024;
+    color: #d14800;
     font-weight: 900;
   }
 
@@ -79,24 +79,11 @@
     border: none;
     padding: 16px 0;
     line-height: 28px;
-  }
-
-  .navbar-action__suggestion {
-    color: #9199a1;
-    display: inline-block;
-    margin-right: 50px;
-  }
-
-  .navbar-action__suggestion:hover {
-    text-decoration: underline;
-  }
-
-  .navbar-action__logout {
-    color: #9199a1;
+    color: #333333;
     display: inline-block;
   }
 
-  .navbar-action__logout:hover {
+  .navbar-action:hover {
     text-decoration: underline;
   }
 
@@ -108,6 +95,10 @@
     list-style: none;
     margin: 0;
     display: inline-flex;
+  }
+
+  .navigation__link {
+    margin-left: 25px;
   }
 
   @media only screen and (min-width: 640px) {

--- a/client/src/components/FeedbackModal.vue
+++ b/client/src/components/FeedbackModal.vue
@@ -154,7 +154,7 @@
     text-align: center;
     vertical-align: middle;
     cursor: pointer;
-    background: #3cc782;
+    background: #008a00;
     outline: none;
     border: none;
     -webkit-border-radius: 3px;

--- a/client/src/components/JobCard.vue
+++ b/client/src/components/JobCard.vue
@@ -239,7 +239,7 @@
   }
 
   .job__locations--empty {
-    color: #6d7882;
+    color: #808080;
   }
 
   .job__footer {

--- a/client/src/components/JobCard.vue
+++ b/client/src/components/JobCard.vue
@@ -208,7 +208,7 @@
   }
 
   .job__mission {
-    color: #5fba7d;
+    color: #288653;
     font-weight: 500;
   }
 
@@ -239,7 +239,7 @@
   }
 
   .job__locations--empty {
-    color: #9199a1;
+    color: #6d7882;
   }
 
   .job__footer {
@@ -250,18 +250,20 @@
 
   .job__apply-button {
     text-transform: uppercase;
-    color: #F57C00;
+    color: #d14800;
     background: #ffffff;
-    border: 1px solid #F48024;
+    border: 1px solid #d14800;
     cursor: pointer;
     padding: 15px 30px;
     border-radius: 4px;
     width: 100%;
     margin-bottom: 10px;
+    font-weight: 700;
   }
 
   .job__apply-button:hover {
-    background: #FFE0B2;
+    background: #d14800;
+    color: #ffffff;
   }
 
   .job__apply-button:disabled,


### PR DESCRIPTION
Résout l'issue #70 

Les couleurs ont modifiées grâce à l'extension Chrome [Accessibility Dev Tools](https://www.google.fr/url?sa=t&rct=j&q=&esrc=s&source=web&cd=1&cad=rja&uact=8&ved=0ahUKEwjo9JOAjonVAhVCiRoKHZDODeUQFggmMAA&url=https%3A%2F%2Fchrome.google.com%2Fwebstore%2Fdetail%2Faccessibility-developer-t%2Ffpkknkljclfencbdbgkenhalefipecmb&usg=AFQjCNG_Dh9c_Y4cZBcq9fRo3z5kzKNxgw) qui fixe le niveau d'acceptation AA à un ratio de contraste de 4,50. 

Les composants modifiés sont : 

- app-header : le logo et les boutons
- job-card : le nom de la mission (vert), la localisation non-renseignée (gris) et le bouton "je suis intéressé" (orange, fond rempli au _hover_)
- feedback-modal : le bouton envoyer