### PR TITLE
Job 65 : Trier les activités entre les missions signées et les propales

### DIFF
--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -21,7 +21,6 @@
 </script>
 
 <style>
-
   body {
     background: #f5f5f5;
     padding: 0;
@@ -34,18 +33,6 @@
     -moz-osx-font-smoothing: grayscale;
     text-align: center;
     color: #2c3e50;
-  }
-
-  .page__body {
-    display: flex;
-    width: 100%;
-    padding: 20px 0;
-    margin-top: 60px;
-    justify-content: center;
-  }
-
-  .page__container {
-    margin: 0 auto;
   }
 
   .v--modal {

--- a/client/src/components/AppHeader.vue
+++ b/client/src/components/AppHeader.vue
@@ -13,11 +13,9 @@
         </nav>
       </div>
     </header>
-
   </div>
 </template>
 <script>
-
   import authenticationService from '@/services/authentication';
 
   export default {
@@ -38,10 +36,8 @@
 
   };
 </script>
-<style scoped>
-  /* App header
-/* ------------------- */
 
+<style scoped>
   .page__header {
     height: 60px;
     background: #ffffff;
@@ -101,6 +97,14 @@
     margin-left: 25px;
   }
 
+  .page__container {
+    margin: 0 auto;
+  }
+
+  .navigation__link {
+    margin-left: 25px;
+  }
+
   @media only screen and (min-width: 640px) {
     .page__header--container {
       justify-content: space-between;
@@ -109,7 +113,5 @@
     .app-header__navigation {
       display: inline-block;
     }
-
   }
-
 </style>

--- a/client/src/components/FeedbackModal.vue
+++ b/client/src/components/FeedbackModal.vue
@@ -18,7 +18,7 @@
         </form>
       </div>
 
-      <!-- modal body -->
+      <!-- modal footer -->
       <div class="feedback-modal__footer">
         <div class="feedback-modal__actions">
           <button class="feedback-modal__action feedback-modal__action--send" @click="sendFeedback">Envoyer</button>
@@ -31,7 +31,6 @@
 </template>
 
 <script>
-
   import authenticationService from '@/services/authentication';
   import feedbacksApi from '@/api/feedbacks';
 
@@ -90,7 +89,6 @@
 </script>
 
 <style scoped>
-
   .feedback-modal__header {
     background-color: #eef0f4;
     padding: 10px 20px;
@@ -181,5 +179,4 @@
   .feedback-modal__action--cancel:hover {
     box-shadow: 0 0 3px 0 #d8dde6;
   }
-
 </style>

--- a/client/src/components/GithubCorner.vue
+++ b/client/src/components/GithubCorner.vue
@@ -9,6 +9,7 @@
     </a>
   </div>
 </template>
+
 <script>
   export default {
     data() {
@@ -18,6 +19,7 @@
     },
   };
 </script>
+
 <style>
   .github-corner__link:hover .octo-arm {
     animation: octocat-wave 560ms ease-in-out

--- a/client/src/components/JobCard.vue
+++ b/client/src/components/JobCard.vue
@@ -23,7 +23,6 @@
 </template>
 
 <script>
-
   import interestsApi from '@/api/interests';
   import authenticationService from '@/services/authentication';
 
@@ -119,11 +118,9 @@
     },
 
   };
-
 </script>
 
 <style scoped>
-
   .sr-only {
     position: absolute;
     width: 1px;
@@ -135,9 +132,6 @@
     border: 0;
     display: block;
   }
-
-  /* Job
-  /* ------------------- */
 
   .job {
     min-width: 260px;
@@ -251,11 +245,6 @@
     font-weight: 500;
   }
 
-  .job__duration {
-    color: #5fba7d;
-    font-weight: 700;
-  }
-
   .job__locations {
     color: #07c;
     font-weight: 500;
@@ -297,15 +286,4 @@
     color: #FAFAFA;
     cursor: auto;
   }
-
-  .job__alert-link {
-    text-decoration: none;
-    font-size: 12px;
-    color: #9199a1;
-  }
-
-  .job__alert-link:hover {
-    text-decoration: underline;
-  }
-
 </style>

--- a/client/src/components/JobCard.vue
+++ b/client/src/components/JobCard.vue
@@ -51,7 +51,7 @@
 
       statusClass() {
         if (this.job.project.status) {
-          return 'job__status job__status--' + this.job.project.status
+          return `job__status job__status--${this.job.project.status}`;
         }
         return '';
       },

--- a/client/src/components/JobCard.vue
+++ b/client/src/components/JobCard.vue
@@ -68,7 +68,7 @@
 
       staffingNeededSince() {
         const staffingNeededSince = new Date(this.job.activity.staffing_needed_from);
-        return staffingNeededSince.toLocaleDateString('fr-FR', { day: 'numeric',month: 'long', year: 'numeric' });
+        return staffingNeededSince.toLocaleDateString('fr-FR', { day: 'numeric', month: 'long', year: 'numeric' });
       },
 
       locations() {

--- a/client/src/components/JobCard.vue
+++ b/client/src/components/JobCard.vue
@@ -3,7 +3,7 @@
     <article class="job">
       <header class="job__header">
         <h2 class="job__title">{{ job.activity.title }}</h2>
-        <span :class="['job__status job__status--'+job.project.status]">{{ job.project.status }}</span>
+        <span :class="['job__status job__status--'+job.project.status]">{{ status }}</span>
       </header>
       <a class="job__content" :href="octopodUrl">
         <p><span class="job__mission">{{ mission }}</span></p>

--- a/client/src/components/JobCard.vue
+++ b/client/src/components/JobCard.vue
@@ -3,7 +3,7 @@
     <article class="job">
       <header class="job__header">
         <h2 class="job__title">{{ job.activity.title }}</h2>
-        <span :class="['job__status job__status--'+job.project.status]">{{ status }}</span>
+        <span :class="statusClass">{{ status }}</span>
       </header>
       <a class="job__content" :href="octopodUrl">
         <p><span class="job__mission">{{ mission }}</span></p>
@@ -15,7 +15,8 @@
       <footer class="job__footer">
         <button class="job__apply-button" :disabled="isClicked" @click.prevent.once="submitInterest"
                 title="Si vous cliquez sur ce bouton, un mail sera envoyé à l'équipe Job Board (uniquement !) avec les informations utiles pour aider au staffing.">
-          Je suis intéressé·e <span class="sr-only">par cette mission {{ mission }} en tant que {{ job.activity.title }}</span>
+          Je suis intéressé·e <span class="sr-only">par cette mission {{ mission }} en tant que {{ job.activity.title
+          }}</span>
         </button>
       </footer>
     </article>
@@ -42,7 +43,17 @@
 
       status() {
         const status = this.job.project.status;
+        if (!status) {
+          return 'propale';
+        }
         return (status.startsWith('mission')) ? 'signé' : 'propale';
+      },
+
+      statusClass() {
+        if (this.job.project.status) {
+          return 'job__status job__status--' + this.job.project.status
+        }
+        return '';
       },
 
       octopodUrl() {
@@ -57,7 +68,7 @@
 
       staffingNeededSince() {
         const staffingNeededSince = new Date(this.job.activity.staffing_needed_from);
-        return staffingNeededSince.toLocaleDateString('fr-FR', { day: 'numeric', month: 'long', year: 'numeric' });
+        return staffingNeededSince.toLocaleDateString('fr-FR', { day: 'numeric',month: 'long', year: 'numeric' });
       },
 
       locations() {
@@ -128,7 +139,7 @@
     padding: 0;
     margin: -1px;
     overflow: hidden;
-    clip: rect(0,0,0,0);
+    clip: rect(0, 0, 0, 0);
     border: 0;
     display: block;
   }

--- a/client/src/components/JobCard.vue
+++ b/client/src/components/JobCard.vue
@@ -177,19 +177,19 @@
     background: orange;
   }
 
-  .job__status--mission-signed {
+  .job__status--mission_signed {
     background: green;
   }
 
-  .job__status--proposal-in-progress {
+  .job__status--proposal_in_progress {
     background: #0000FF;
   }
 
-  .job__status--proposal-sent {
+  .job__status--proposal_sent {
     background: #6699FF;
   }
 
-  .job__status--mission-accepted {
+  .job__status--mission_accepted {
     background-color: #33CC00;
   }
 

--- a/client/src/components/JobCard.vue
+++ b/client/src/components/JobCard.vue
@@ -42,7 +42,7 @@
 
       status() {
         const status = this.job.project.status;
-        return (status.startsWith('mission')) ? 'mission' : 'propale';
+        return (status.startsWith('mission')) ? 'signé' : 'propale';
       },
 
       octopodUrl() {

--- a/client/src/components/JobCard.vue
+++ b/client/src/components/JobCard.vue
@@ -3,7 +3,7 @@
     <article class="job">
       <header class="job__header">
         <h2 class="job__title">{{ job.activity.title }}</h2>
-        <span :class="['job__status job__status--'+job.project.status]"></span>
+        <span :class="['job__status job__status--'+job.project.status]">{{ job.project.status }}</span>
       </header>
       <a class="job__content" :href="octopodUrl">
         <p><span class="job__mission">{{ mission }}</span></p>
@@ -40,6 +40,11 @@
     },
 
     computed: {
+
+      status() {
+        const status = this.job.project.status;
+        return (status.startsWith('mission')) ? 'mission' : 'propale';
+      },
 
       octopodUrl() {
         const octopodProjectId = this.job.project.id;
@@ -165,31 +170,49 @@
     max-width: 200px;
   }
 
+  /* used line 6*/
   .job__status {
     display: inline-block;
-    width: 17px;
-    height: 17px;
-    border-radius: 50%;
+    border-radius: 3px;
     margin-left: 5px;
+    text-transform: uppercase;
+    padding: 5px 8px;
+    color: white;
+    font-size: 11px
   }
 
+  /* not used*/
   .job__status--lead {
     background: orange;
   }
 
+  /* not used*/
   .job__status--mission_signed {
     background: green;
   }
 
+  /* not used*/
   .job__status--proposal_in_progress {
     background: #0000FF;
   }
 
+  /* not used*/
   .job__status--proposal_sent {
     background: #6699FF;
   }
 
+  /* not used*/
   .job__status--mission_accepted {
+    background-color: #33CC00;
+  }
+
+  /* used line 6*/
+  .job__status--propale {
+    background: #6699FF;
+  }
+
+  /* used line 6*/
+  .job__status--mission {
     background-color: #33CC00;
   }
 

--- a/client/src/components/JobList.vue
+++ b/client/src/components/JobList.vue
@@ -57,10 +57,28 @@
 
       _sortJobs(jobs) {
         return jobs.sort((job1, job2) => {
-          if (job1.project.status.startsWith('mission')) {
+          if (job1.project.status === 'mission_signed') {
             return -1;
           }
-          if (job2.project.status.startsWith('mission')) {
+          if (job2.project.status === 'mission_signed') {
+            return 1;
+          }
+          if (job1.project.status === 'mission_accepted') {
+            return -1;
+          }
+          if (job2.project.status === 'mission_accepted') {
+            return 1;
+          }
+          if (job1.project.status === 'proposal_sent') {
+            return -1;
+          }
+          if (job2.project.status === 'proposal_sent') {
+            return 1;
+          }
+          if (job1.project.status === 'proposal_in_progress') {
+            return -1;
+          }
+          if (job2.project.status === 'proposal_in_progress') {
             return 1;
           }
           return 0;

--- a/client/src/components/JobList.vue
+++ b/client/src/components/JobList.vue
@@ -20,6 +20,7 @@
 
 <script>
   import authenticationService from '@/services/authentication';
+  import projectStatus from '@/utils/projectStatus';
   import jobsApi from '@/api/jobs';
   import AppHeader from '@/components/AppHeader';
   import JobCard from '@/components/JobCard';
@@ -50,39 +51,13 @@
           const accessToken = authenticationService.getAccessToken();
 
           jobsApi.fetchAll(accessToken).then((jobs) => {
-            this.jobs = this._sortJobs(jobs);
+            this.jobs = this._sortJobsByProjectStatus(jobs);
           });
         }
       },
 
-      _sortJobs(jobs) {
-        return jobs.sort((job1, job2) => {
-          if (job1.project.status === 'mission_signed') {
-            return -1;
-          }
-          if (job2.project.status === 'mission_signed') {
-            return 1;
-          }
-          if (job1.project.status === 'mission_accepted') {
-            return -1;
-          }
-          if (job2.project.status === 'mission_accepted') {
-            return 1;
-          }
-          if (job1.project.status === 'proposal_sent') {
-            return -1;
-          }
-          if (job2.project.status === 'proposal_sent') {
-            return 1;
-          }
-          if (job1.project.status === 'proposal_in_progress') {
-            return -1;
-          }
-          if (job2.project.status === 'proposal_in_progress') {
-            return 1;
-          }
-          return 0;
-        });
+      _sortJobsByProjectStatus(jobs) {
+        return projectStatus.sort(jobs);
       },
     },
   };

--- a/client/src/components/JobList.vue
+++ b/client/src/components/JobList.vue
@@ -54,11 +54,22 @@
           const accessToken = authenticationService.getAccessToken();
 
           jobsApi.fetchAll(accessToken).then((jobs) => {
-            this.jobs = jobs;
+            this.jobs = this._sortJobs(jobs);
           });
         }
       },
 
+      _sortJobs(jobs) {
+        return jobs.sort((job1, job2) => {
+          if (job1.project.status.startsWith('mission')) {
+            return -1;
+          }
+          if (job2.project.status.startsWith('mission')) {
+            return 1;
+          }
+          return 0;
+        })
+      }
     },
   };
 </script>

--- a/client/src/components/JobList.vue
+++ b/client/src/components/JobList.vue
@@ -1,12 +1,9 @@
 <template>
   <div class="page page__jobs">
     <app-header/>
-
     <main class="page__body">
       <div class="page__container">
-
         <div class="job-results-panel">
-
           <section class="job-results job-results--delivery">
             <h1 class="job-results__title">Missions à staffer ({{ jobs.length }})</h1>
             <ul class="job-results__list">
@@ -22,7 +19,6 @@
 </template>
 
 <script>
-
   import authenticationService from '@/services/authentication';
   import jobsApi from '@/api/jobs';
   import AppHeader from '@/components/AppHeader';
@@ -68,15 +64,20 @@
             return 1;
           }
           return 0;
-        })
-      }
+        });
+      },
     },
   };
 </script>
 
 <style scoped>
-  /* Job results
-  /* ------------------- */
+  .page__body {
+    display: flex;
+    width: 100%;
+    padding: 20px 0;
+    margin-top: 60px;
+    justify-content: center;
+  }
 
   .job-results {
     margin-bottom: 60px;
@@ -106,5 +107,4 @@
       flex-wrap: wrap;
     }
   }
-
 </style>

--- a/client/src/components/LoginPage.vue
+++ b/client/src/components/LoginPage.vue
@@ -1,20 +1,15 @@
 <template>
-
   <div class="login">
-
     <g-signin-button
       :params="googleSignInParams"
       @success="onSignInSuccess"
       @error="onSignInError">
       Sign in with Google
     </g-signin-button>
-
   </div>
-
 </template>
 
 <script>
-
   import Vue from 'vue';
   import GSignInButton from 'vue-google-signin-button';
   import authentication from '@/services/authentication';
@@ -49,7 +44,6 @@
 </script>
 
 <style scoped>
-
   .g-signin-button {
     display: inline-block;
     padding: 4px 8px;

--- a/client/src/utils/projectStatus.js
+++ b/client/src/utils/projectStatus.js
@@ -1,0 +1,40 @@
+// let projectStatus = new Map();
+// projectStatus.set('mission_signed')
+// projectStatus.set('mission_accepted')
+// projectStatus.set('proposal_sent')
+// projectStatus.set('proposal_in_progress')
+// projectStatus.set('lead')
+
+export default {
+
+  sort(jobs) {
+    return jobs.sort((job1, job2) => {
+      if (job1.project.status === 'mission_signed') {
+        return -1;
+      }
+      if (job2.project.status === 'mission_signed') {
+        return 1;
+      }
+      if (job1.project.status === 'mission_accepted') {
+        return -1;
+      }
+      if (job2.project.status === 'mission_accepted') {
+        return 1;
+      }
+      if (job1.project.status === 'proposal_sent') {
+        return -1;
+      }
+      if (job2.project.status === 'proposal_sent') {
+        return 1;
+      }
+      if (job1.project.status === 'proposal_in_progress') {
+        return -1;
+      }
+      if (job2.project.status === 'proposal_in_progress') {
+        return 1;
+      }
+      return 0;
+    });
+  },
+
+}

--- a/client/src/utils/projectStatus.js
+++ b/client/src/utils/projectStatus.js
@@ -37,4 +37,4 @@ export default {
     });
   },
 
-}
+};

--- a/client/test/unit/specs/components/JobCard.spec.js
+++ b/client/test/unit/specs/components/JobCard.spec.js
@@ -225,7 +225,7 @@ describe.skip('Unit | Component | JobCard.vue', () => {
   });
 
   describe('computed property #status', () => {
-    it('should return status is mission when api status is mission_accepted', () => {
+    it('should return status is signé when api status is mission_accepted', () => {
       // Given
       job.project.status = 'mission_accepted';
 
@@ -233,10 +233,10 @@ describe.skip('Unit | Component | JobCard.vue', () => {
       const status = component.status;
 
       // Then
-      expect(status).to.equal('mission');
+      expect(status).to.equal('signé');
     });
 
-    it('should return status is mission when api status is mission_signed', () => {
+    it('should return status is signé when api status is mission_signed', () => {
       // Given
       job.project.status = 'mission_signed';
 
@@ -244,7 +244,7 @@ describe.skip('Unit | Component | JobCard.vue', () => {
       const status = component.status;
 
       // Then
-      expect(status).to.equal('mission');
+      expect(status).to.equal('signé');
     });
 
     it('should return status is propale when api status is proposal_in_progress', () => {

--- a/client/test/unit/specs/components/JobCard.spec.js
+++ b/client/test/unit/specs/components/JobCard.spec.js
@@ -223,4 +223,61 @@ describe.skip('Unit | Component | JobCard.vue', () => {
       expect(octopodUrl).to.equal('https://octopod.octo.com/projects/12357');
     });
   });
+
+  describe('computed property #status', () => {
+    it('should return status is mission when api status is mission_accepted', () => {
+      // Given
+      job.project.status = 'mission_accepted';
+
+      // When
+      const status = component.status;
+
+      // Then
+      expect(status).to.equal('mission');
+    });
+
+    it('should return status is mission when api status is mission_signed', () => {
+      // Given
+      job.project.status = 'mission_signed';
+
+      // When
+      const status = component.status;
+
+      // Then
+      expect(status).to.equal('mission');
+    });
+
+    it('should return status is propale when api status is proposal_in_progress', () => {
+      // Given
+      job.project.status = 'proposal_in_progress';
+
+      // When
+      const status = component.status;
+
+      // Then
+      expect(status).to.equal('propale');
+    });
+
+    it('should return status is propale when api status is proposal_sent', () => {
+      // Given
+      job.project.status = 'proposal_sent';
+
+      // When
+      const status = component.status;
+
+      // Then
+      expect(status).to.equal('propale');
+    });
+
+    it('should return status is propale when api status is lead', () => {
+      // Given
+      job.project.status = 'lead';
+
+      // When
+      const status = component.status;
+
+      // Then
+      expect(status).to.equal('propale');
+    });
+  });
 });

--- a/client/test/unit/specs/components/JobCard.spec.js
+++ b/client/test/unit/specs/components/JobCard.spec.js
@@ -1,15 +1,15 @@
-import Vue from 'vue';
-import VueAnalytics from 'vue-analytics';
-import JobCard from '@/components/JobCard';
-import interestsApi from '@/api/interests';
-import authenticationService from '@/services/authentication';
+import Vue from 'vue'
+import VueAnalytics from 'vue-analytics'
+import JobCard from '@/components/JobCard'
+import interestsApi from '@/api/interests'
+import authenticationService from '@/services/authentication'
 
 Vue.use(VueAnalytics, {
   id: `${process.env.ANALYTICS_ID}`,
-});
+})
 
 describe.skip('Unit | Component | JobCard.vue', () => {
-  let component;
+  let component
   const job = {
     id: 2,
     activity: {
@@ -32,92 +32,92 @@ describe.skip('Unit | Component | JobCard.vue', () => {
         nickname: 'XYZ',
       },
     },
-  };
+  }
 
   const consultant = {
     name: 'Samurai Jack',
     email: 'sjack@octo.com',
-  };
-  const accessToken = 'abcd-1234';
+  }
+  const accessToken = 'abcd-1234'
 
   beforeEach(() => {
     // given
-    sinon.stub(authenticationService, 'isAuthenticated').returns(true);
-    sinon.stub(authenticationService, 'getAuthenticatedUser').returns(consultant);
-    sinon.stub(authenticationService, 'getAccessToken').returns(accessToken);
-    sinon.stub(interestsApi, 'sendInterest').resolves();
+    sinon.stub(authenticationService, 'isAuthenticated').returns(true)
+    sinon.stub(authenticationService, 'getAuthenticatedUser').returns(consultant)
+    sinon.stub(authenticationService, 'getAccessToken').returns(accessToken)
+    sinon.stub(interestsApi, 'sendInterest').resolves()
 
     // when
-    const Constructor = Vue.extend(JobCard);
+    const Constructor = Vue.extend(JobCard)
     component = new Constructor({
       data: {
         job,
         isClicked: false,
       },
-    }).$mount();
-  });
+    }).$mount()
+  })
 
   afterEach(() => {
-    authenticationService.isAuthenticated.restore();
-    authenticationService.getAuthenticatedUser.restore();
-    authenticationService.getAccessToken.restore();
-    interestsApi.sendInterest.restore();
-  });
+    authenticationService.isAuthenticated.restore()
+    authenticationService.getAuthenticatedUser.restore()
+    authenticationService.getAccessToken.restore()
+    interestsApi.sendInterest.restore()
+  })
 
   describe('name', () => {
     it('should be named "JobCard"', () => {
-      expect(component.$options.name).to.equal('JobCard');
-    });
-  });
+      expect(component.$options.name).to.equal('JobCard')
+    })
+  })
 
   describe('$data', () => {
     it('should have isClicked property set to false', () => {
-      expect(component.$data.isClicked).to.be.false;
-    });
-  });
+      expect(component.$data.isClicked).to.be.false
+    })
+  })
 
   describe('rendering', () => {
     it('should display the appropriate project status', () => {
-      expect(component.$el.querySelector('.job__status').getAttribute('class')).to.contain('job__status--proposal_in_progress');
-    });
+      expect(component.$el.querySelector('.job__status').getAttribute('class')).to.contain('job__status--proposal_in_progress')
+    })
 
     it('should display the activity title', () => {
-      expect(component.$el.querySelector('.job__title').textContent.trim()).to.equal('Tech Lead');
-    });
+      expect(component.$el.querySelector('.job__title').textContent.trim()).to.equal('Tech Lead')
+    })
 
     it('should display the mission name', () => {
-      expect(component.$el.querySelector('.job__mission').textContent.trim()).to.equal('Refonte du SI');
-    });
+      expect(component.$el.querySelector('.job__mission').textContent.trim()).to.equal('Refonte du SI')
+    })
 
     it('should display the client name', () => {
-      expect(component.$el.querySelector('.job__customer').textContent.trim()).to.equal('La Poste - Courrier');
-    });
+      expect(component.$el.querySelector('.job__customer').textContent.trim()).to.equal('La Poste - Courrier')
+    })
 
     // TODO: it works on local or on browser, but fails in CircleCI :-/
     it('should display the staffing_needed_from', () => {
-      expect(component.$el.querySelector('.job__start-date').textContent.trim()).to.equal('1 juillet 2017');
-    });
+      expect(component.$el.querySelector('.job__start-date').textContent.trim()).to.equal('1 juillet 2017')
+    })
 
     it('should display the locations', () => {
-      expect(component.$el.querySelector('.job__locations').textContent.trim()).to.equal('OCTO');
-    });
+      expect(component.$el.querySelector('.job__locations').textContent.trim()).to.equal('OCTO')
+    })
 
     it('should have enabled button', () => {
-      expect(component.$el.querySelector('.job__apply-button').disabled).to.be.false;
-    });
-  });
+      expect(component.$el.querySelector('.job__apply-button').disabled).to.be.false
+    })
+  })
 
   describe('clicking on button "I am interested in"', () => {
     it('should disable button', () => {
       // when
-      component.$el.querySelector('button.job__apply-button').click();
+      component.$el.querySelector('button.job__apply-button').click()
 
       // then
       Vue.nextTick().then(() => {
-        expect(component.$el.querySelector('.job__apply-button').disabled).to.be.true;
-      });
-    });
-  });
+        expect(component.$el.querySelector('.job__apply-button').disabled).to.be.true
+      })
+    })
+  })
 
   describe('method #trackEvent', () => {
     const expectedCallParams = {
@@ -125,159 +125,194 @@ describe.skip('Unit | Component | JobCard.vue', () => {
       eventAction: 'click',
       eventLabel: 'I am interested',
       eventValue: null,
-    };
+    }
 
     beforeEach(() => {
-      sinon.stub(component.$ga, 'event').returns(true);
-    });
+      sinon.stub(component.$ga, 'event').returns(true)
+    })
 
     afterEach(() => {
-      component.$ga.event.restore();
-    });
+      component.$ga.event.restore()
+    })
 
     it('should check analytics', () => {
       // when
-      component.trackEvent();
+      component.trackEvent()
 
       // then
-      expect(component.$ga.event).to.have.been.calledWith(expectedCallParams);
-    });
+      expect(component.$ga.event).to.have.been.calledWith(expectedCallParams)
+    })
 
     it('on click on button job__apply-button', () => Vue.nextTick().then(() => {
       // when
-      component.$el.querySelector('button.job__apply-button').click();
+      component.$el.querySelector('button.job__apply-button').click()
 
       // then
-      expect(component.$ga.event).to.have.been.calledWith(expectedCallParams);
-    }));
-  });
+      expect(component.$ga.event).to.have.been.calledWith(expectedCallParams)
+    }))
+  })
 
   describe('method #sendInterest', () => {
     it('should call the API with good params', () => {
       // when
-      component.sendInterest();
+      component.sendInterest()
 
       // then
-      expect(interestsApi.sendInterest).to.have.been.calledWithExactly(job, consultant, accessToken);
-    });
+      expect(interestsApi.sendInterest).to.have.been.calledWithExactly(job, consultant, accessToken)
+    })
 
     it('should send interests on click on job__apply-button', () => Vue.nextTick().then(() => {
       // Given
-      const myButton = component.$el.querySelector('button.job__apply-button');
+      const myButton = component.$el.querySelector('button.job__apply-button')
 
       // When
-      myButton.click();
+      myButton.click()
 
       // Then
-      expect(interestsApi.sendInterest).to.have.been.calledWithExactly(job, consultant, accessToken);
-    }));
-  });
+      expect(interestsApi.sendInterest).to.have.been.calledWithExactly(job, consultant, accessToken)
+    }))
+  })
 
   describe('computed property #mission', () => {
     it('should not shorten short mission name', () => {
       // Given
-      job.project.name = 'Name shorter than 50 characters';
+      job.project.name = 'Name shorter than 50 characters'
 
       // When
-      const missionName = component.mission;
+      const missionName = component.mission
 
       // Then
-      expect(missionName).to.equal('Name shorter than 50 characters');
-    });
+      expect(missionName).to.equal('Name shorter than 50 characters')
+    })
 
     it('should shorten long mission name to 50 characters', () => {
       // Given
-      job.project.name = 'SCLOU - Cloud computing : enjeux, architecture et gouvernance du IaaS, CaaS, PaaS INTER 2017';
+      job.project.name = 'SCLOU - Cloud computing : enjeux, architecture et gouvernance du IaaS, CaaS, PaaS INTER 2017'
 
       // When
-      const missionName = component.mission;
+      const missionName = component.mission
 
       // Then
-      expect(missionName).to.equal('SCLOU - Cloud computing : enjeux, architecture et');
-    });
-  });
+      expect(missionName).to.equal('SCLOU - Cloud computing : enjeux, architecture et')
+    })
+  })
 
   describe('computed property #staffingNeededSince', () => {
     // TODO: it works on local or on browser, but fails in CircleCI :-/
     it.skip('should format the mission staffing_needed_from date (ex : "2017-07-01" => "Juillet 2017")', () => {
       // Given
-      job.project.staffing_needed_from = '2017-07-01';
+      job.project.staffing_needed_from = '2017-07-01'
 
       // When
       const staffingNeededSince = component.staffingNeededSince;
 
       // Then
-      expect(staffingNeededSince).to.contain('juillet 2017');
-    });
-  });
+      expect(staffingNeededSince).to.contain('juillet 2017')
+    })
+  })
 
   describe('computed property #octopodUrl', () => {
     it('should format the link to Octopod project page', () => {
       // Given
-      job.project.id = 12357;
+      job.project.id = 12357
 
       // When
-      const octopodUrl = component.octopodUrl;
+      const octopodUrl = component.octopodUrl
 
       // Then
-      expect(octopodUrl).to.equal('https://octopod.octo.com/projects/12357');
-    });
-  });
+      expect(octopodUrl).to.equal('https://octopod.octo.com/projects/12357')
+    })
+  })
+
+  describe('computed property #statusClass', () => {
+    it('should return job__status--"project status" class when api status is correct', () => {
+      // Given
+      job.project.status = 'mission_accepted'
+
+      // When
+      const statusClass = component.statusClass
+
+      // Then
+      expect(statusClass).to.equal('job__status job__status--mission_accepted')
+    })
+
+    it('should return empty string when api status is undefined', () => {
+      // Given
+      job.project.status = null;
+
+      // When
+      const statusClass = component.statusClass
+
+      // Then
+      expect(statusClass).to.equal('')
+    })
+  })
 
   describe('computed property #status', () => {
-    it('should return status is signé when api status is mission_accepted', () => {
+    it('should return status is propale when api status is null', () => {
       // Given
-      job.project.status = 'mission_accepted';
+      job.project.status = null
 
       // When
-      const status = component.status;
+      const status = component.status
 
       // Then
-      expect(status).to.equal('signé');
-    });
+      expect(status).to.equal('propale')
+    })
+
+    it('should return status is signé when api status is mission_accepted', () => {
+      // Given
+      job.project.status = 'mission_accepted'
+
+      // When
+      const status = component.status
+
+      // Then
+      expect(status).to.equal('signé')
+    })
 
     it('should return status is signé when api status is mission_signed', () => {
       // Given
-      job.project.status = 'mission_signed';
+      job.project.status = 'mission_signed'
 
       // When
-      const status = component.status;
+      const status = component.status
 
       // Then
-      expect(status).to.equal('signé');
-    });
+      expect(status).to.equal('signé')
+    })
 
     it('should return status is propale when api status is proposal_in_progress', () => {
       // Given
-      job.project.status = 'proposal_in_progress';
+      job.project.status = 'proposal_in_progress'
 
       // When
-      const status = component.status;
+      const status = component.status
 
       // Then
-      expect(status).to.equal('propale');
-    });
+      expect(status).to.equal('propale')
+    })
 
     it('should return status is propale when api status is proposal_sent', () => {
       // Given
-      job.project.status = 'proposal_sent';
+      job.project.status = 'proposal_sent'
 
       // When
-      const status = component.status;
+      const status = component.status
 
       // Then
-      expect(status).to.equal('propale');
-    });
+      expect(status).to.equal('propale')
+    })
 
     it('should return status is propale when api status is lead', () => {
       // Given
-      job.project.status = 'lead';
+      job.project.status = 'lead'
 
       // When
-      const status = component.status;
+      const status = component.status
 
       // Then
-      expect(status).to.equal('propale');
-    });
-  });
-});
+      expect(status).to.equal('propale')
+    })
+  })
+})

--- a/client/test/unit/specs/components/JobCard.spec.js
+++ b/client/test/unit/specs/components/JobCard.spec.js
@@ -17,7 +17,7 @@ describe.skip('Unit | Component | JobCard.vue', () => {
     },
     project: {
       id: 123456,
-      status: 'proposal-in-progress',
+      status: 'proposal_in_progress',
       name: 'Refonte du SI',
       customer: {
         name: 'La Poste - Courrier',
@@ -78,7 +78,7 @@ describe.skip('Unit | Component | JobCard.vue', () => {
 
   describe('rendering', () => {
     it('should display the appropriate project status', () => {
-      expect(component.$el.querySelector('.job__status').getAttribute('class')).to.contain('job__status--proposal-in-progress');
+      expect(component.$el.querySelector('.job__status').getAttribute('class')).to.contain('job__status--proposal_in_progress');
     });
 
     it('should display the activity title', () => {

--- a/client/test/unit/specs/components/JobCard.spec.js
+++ b/client/test/unit/specs/components/JobCard.spec.js
@@ -1,15 +1,15 @@
-import Vue from 'vue'
-import VueAnalytics from 'vue-analytics'
-import JobCard from '@/components/JobCard'
-import interestsApi from '@/api/interests'
-import authenticationService from '@/services/authentication'
+import Vue from 'vue';
+import VueAnalytics from 'vue-analytics';
+import JobCard from '@/components/JobCard';
+import interestsApi from '@/api/interests';
+import authenticationService from '@/services/authentication';
 
 Vue.use(VueAnalytics, {
   id: `${process.env.ANALYTICS_ID}`,
-})
+});
 
 describe.skip('Unit | Component | JobCard.vue', () => {
-  let component
+  let component;
   const job = {
     id: 2,
     activity: {
@@ -32,92 +32,92 @@ describe.skip('Unit | Component | JobCard.vue', () => {
         nickname: 'XYZ',
       },
     },
-  }
+  };
 
   const consultant = {
     name: 'Samurai Jack',
     email: 'sjack@octo.com',
-  }
-  const accessToken = 'abcd-1234'
+  };
+  const accessToken = 'abcd-1234';
 
   beforeEach(() => {
     // given
-    sinon.stub(authenticationService, 'isAuthenticated').returns(true)
-    sinon.stub(authenticationService, 'getAuthenticatedUser').returns(consultant)
-    sinon.stub(authenticationService, 'getAccessToken').returns(accessToken)
-    sinon.stub(interestsApi, 'sendInterest').resolves()
+    sinon.stub(authenticationService, 'isAuthenticated').returns(true);
+    sinon.stub(authenticationService, 'getAuthenticatedUser').returns(consultant);
+    sinon.stub(authenticationService, 'getAccessToken').returns(accessToken);
+    sinon.stub(interestsApi, 'sendInterest').resolves();
 
     // when
-    const Constructor = Vue.extend(JobCard)
+    const Constructor = Vue.extend(JobCard);
     component = new Constructor({
       data: {
         job,
         isClicked: false,
       },
-    }).$mount()
-  })
+    }).$mount();
+  });
 
   afterEach(() => {
-    authenticationService.isAuthenticated.restore()
-    authenticationService.getAuthenticatedUser.restore()
-    authenticationService.getAccessToken.restore()
-    interestsApi.sendInterest.restore()
-  })
+    authenticationService.isAuthenticated.restore();
+    authenticationService.getAuthenticatedUser.restore();
+    authenticationService.getAccessToken.restore();
+    interestsApi.sendInterest.restore();
+  });
 
   describe('name', () => {
     it('should be named "JobCard"', () => {
-      expect(component.$options.name).to.equal('JobCard')
-    })
-  })
+      expect(component.$options.name).to.equal('JobCard');
+    });
+  });
 
   describe('$data', () => {
     it('should have isClicked property set to false', () => {
-      expect(component.$data.isClicked).to.be.false
-    })
-  })
+      expect(component.$data.isClicked).to.be.false;
+    });
+  });
 
   describe('rendering', () => {
     it('should display the appropriate project status', () => {
-      expect(component.$el.querySelector('.job__status').getAttribute('class')).to.contain('job__status--proposal_in_progress')
-    })
+      expect(component.$el.querySelector('.job__status').getAttribute('class')).to.contain('job__status--proposal_in_progress');
+    });
 
     it('should display the activity title', () => {
-      expect(component.$el.querySelector('.job__title').textContent.trim()).to.equal('Tech Lead')
-    })
+      expect(component.$el.querySelector('.job__title').textContent.trim()).to.equal('Tech Lead');
+    });
 
     it('should display the mission name', () => {
-      expect(component.$el.querySelector('.job__mission').textContent.trim()).to.equal('Refonte du SI')
-    })
+      expect(component.$el.querySelector('.job__mission').textContent.trim()).to.equal('Refonte du SI');
+    });
 
     it('should display the client name', () => {
-      expect(component.$el.querySelector('.job__customer').textContent.trim()).to.equal('La Poste - Courrier')
-    })
+      expect(component.$el.querySelector('.job__customer').textContent.trim()).to.equal('La Poste - Courrier');
+    });
 
     // TODO: it works on local or on browser, but fails in CircleCI :-/
     it('should display the staffing_needed_from', () => {
-      expect(component.$el.querySelector('.job__start-date').textContent.trim()).to.equal('1 juillet 2017')
-    })
+      expect(component.$el.querySelector('.job__start-date').textContent.trim()).to.equal('1 juillet 2017');
+    });
 
     it('should display the locations', () => {
-      expect(component.$el.querySelector('.job__locations').textContent.trim()).to.equal('OCTO')
-    })
+      expect(component.$el.querySelector('.job__locations').textContent.trim()).to.equal('OCTO');
+    });
 
     it('should have enabled button', () => {
-      expect(component.$el.querySelector('.job__apply-button').disabled).to.be.false
-    })
-  })
+      expect(component.$el.querySelector('.job__apply-button').disabled).to.be.false;
+    });
+  });
 
   describe('clicking on button "I am interested in"', () => {
     it('should disable button', () => {
       // when
-      component.$el.querySelector('button.job__apply-button').click()
+      component.$el.querySelector('button.job__apply-button').click();
 
       // then
       Vue.nextTick().then(() => {
-        expect(component.$el.querySelector('.job__apply-button').disabled).to.be.true
-      })
-    })
-  })
+        expect(component.$el.querySelector('.job__apply-button').disabled).to.be.true;
+      });
+    });
+  });
 
   describe('method #trackEvent', () => {
     const expectedCallParams = {
@@ -125,194 +125,194 @@ describe.skip('Unit | Component | JobCard.vue', () => {
       eventAction: 'click',
       eventLabel: 'I am interested',
       eventValue: null,
-    }
+    };
 
     beforeEach(() => {
-      sinon.stub(component.$ga, 'event').returns(true)
-    })
+      sinon.stub(component.$ga, 'event').returns(true);
+    });
 
     afterEach(() => {
-      component.$ga.event.restore()
-    })
+      component.$ga.event.restore();
+    });
 
     it('should check analytics', () => {
       // when
-      component.trackEvent()
+      component.trackEvent();
 
       // then
-      expect(component.$ga.event).to.have.been.calledWith(expectedCallParams)
-    })
+      expect(component.$ga.event).to.have.been.calledWith(expectedCallParams);
+    });
 
     it('on click on button job__apply-button', () => Vue.nextTick().then(() => {
       // when
-      component.$el.querySelector('button.job__apply-button').click()
+      component.$el.querySelector('button.job__apply-button').click();
 
       // then
-      expect(component.$ga.event).to.have.been.calledWith(expectedCallParams)
-    }))
-  })
+      expect(component.$ga.event).to.have.been.calledWith(expectedCallParams);
+    }));
+  });
 
   describe('method #sendInterest', () => {
     it('should call the API with good params', () => {
       // when
-      component.sendInterest()
+      component.sendInterest();
 
       // then
-      expect(interestsApi.sendInterest).to.have.been.calledWithExactly(job, consultant, accessToken)
-    })
+      expect(interestsApi.sendInterest).to.have.been.calledWithExactly(job, consultant, accessToken);
+    });
 
     it('should send interests on click on job__apply-button', () => Vue.nextTick().then(() => {
       // Given
-      const myButton = component.$el.querySelector('button.job__apply-button')
+      const myButton = component.$el.querySelector('button.job__apply-button');
 
       // When
-      myButton.click()
+      myButton.click();
 
       // Then
-      expect(interestsApi.sendInterest).to.have.been.calledWithExactly(job, consultant, accessToken)
-    }))
-  })
+      expect(interestsApi.sendInterest).to.have.been.calledWithExactly(job, consultant, accessToken);
+    }));
+  });
 
   describe('computed property #mission', () => {
     it('should not shorten short mission name', () => {
       // Given
-      job.project.name = 'Name shorter than 50 characters'
+      job.project.name = 'Name shorter than 50 characters';
 
       // When
-      const missionName = component.mission
+      const missionName = component.mission;
 
       // Then
-      expect(missionName).to.equal('Name shorter than 50 characters')
-    })
+      expect(missionName).to.equal('Name shorter than 50 characters');
+    });
 
     it('should shorten long mission name to 50 characters', () => {
       // Given
-      job.project.name = 'SCLOU - Cloud computing : enjeux, architecture et gouvernance du IaaS, CaaS, PaaS INTER 2017'
+      job.project.name = 'SCLOU - Cloud computing : enjeux, architecture et gouvernance du IaaS, CaaS, PaaS INTER 2017';
 
       // When
-      const missionName = component.mission
+      const missionName = component.mission;
 
       // Then
-      expect(missionName).to.equal('SCLOU - Cloud computing : enjeux, architecture et')
-    })
-  })
+      expect(missionName).to.equal('SCLOU - Cloud computing : enjeux, architecture et');
+    });
+  });
 
   describe('computed property #staffingNeededSince', () => {
     // TODO: it works on local or on browser, but fails in CircleCI :-/
     it.skip('should format the mission staffing_needed_from date (ex : "2017-07-01" => "Juillet 2017")', () => {
       // Given
-      job.project.staffing_needed_from = '2017-07-01'
+      job.project.staffing_needed_from = '2017-07-01';
 
       // When
       const staffingNeededSince = component.staffingNeededSince;
 
       // Then
-      expect(staffingNeededSince).to.contain('juillet 2017')
-    })
-  })
+      expect(staffingNeededSince).to.contain('juillet 2017');
+    });
+  });
 
   describe('computed property #octopodUrl', () => {
     it('should format the link to Octopod project page', () => {
       // Given
-      job.project.id = 12357
+      job.project.id = 12357;
 
       // When
-      const octopodUrl = component.octopodUrl
+      const octopodUrl = component.octopodUrl;
 
       // Then
-      expect(octopodUrl).to.equal('https://octopod.octo.com/projects/12357')
-    })
-  })
+      expect(octopodUrl).to.equal('https://octopod.octo.com/projects/12357');
+    });
+  });
 
   describe('computed property #statusClass', () => {
     it('should return job__status--"project status" class when api status is correct', () => {
       // Given
-      job.project.status = 'mission_accepted'
+      job.project.status = 'mission_accepted';
 
       // When
-      const statusClass = component.statusClass
+      const statusClass = component.statusClass;
 
       // Then
-      expect(statusClass).to.equal('job__status job__status--mission_accepted')
-    })
+      expect(statusClass).to.equal('job__status job__status--mission_accepted');
+    });
 
     it('should return empty string when api status is undefined', () => {
       // Given
       job.project.status = null;
 
       // When
-      const statusClass = component.statusClass
+      const statusClass = component.statusClass;
 
       // Then
-      expect(statusClass).to.equal('')
-    })
-  })
+      expect(statusClass).to.equal('');
+    });
+  });
 
   describe('computed property #status', () => {
     it('should return status is propale when api status is null', () => {
       // Given
-      job.project.status = null
+      job.project.status = null;
 
       // When
-      const status = component.status
+      const status = component.status;
 
       // Then
-      expect(status).to.equal('propale')
-    })
+      expect(status).to.equal('propale');
+    });
 
     it('should return status is signé when api status is mission_accepted', () => {
       // Given
-      job.project.status = 'mission_accepted'
+      job.project.status = 'mission_accepted';
 
       // When
-      const status = component.status
+      const status = component.status;
 
       // Then
-      expect(status).to.equal('signé')
-    })
+      expect(status).to.equal('signé');
+    });
 
     it('should return status is signé when api status is mission_signed', () => {
       // Given
-      job.project.status = 'mission_signed'
+      job.project.status = 'mission_signed';
 
       // When
-      const status = component.status
+      const status = component.status;
 
       // Then
-      expect(status).to.equal('signé')
-    })
+      expect(status).to.equal('signé');
+    });
 
     it('should return status is propale when api status is proposal_in_progress', () => {
       // Given
-      job.project.status = 'proposal_in_progress'
+      job.project.status = 'proposal_in_progress';
 
       // When
-      const status = component.status
+      const status = component.status;
 
       // Then
-      expect(status).to.equal('propale')
-    })
+      expect(status).to.equal('propale');
+    });
 
     it('should return status is propale when api status is proposal_sent', () => {
       // Given
-      job.project.status = 'proposal_sent'
+      job.project.status = 'proposal_sent';
 
       // When
-      const status = component.status
+      const status = component.status;
 
       // Then
-      expect(status).to.equal('propale')
-    })
+      expect(status).to.equal('propale');
+    });
 
     it('should return status is propale when api status is lead', () => {
       // Given
-      job.project.status = 'lead'
+      job.project.status = 'lead';
 
       // When
-      const status = component.status
+      const status = component.status;
 
       // Then
-      expect(status).to.equal('propale')
-    })
-  })
-})
+      expect(status).to.equal('propale');
+    });
+  });
+});

--- a/client/test/unit/specs/components/JobList.spec.js
+++ b/client/test/unit/specs/components/JobList.spec.js
@@ -83,7 +83,8 @@ describe('Unit | Component | JobList.vue', () => {
             nickname: 'XYZ',
           },
         },
-      }, {
+      },
+      {
         id: 4,
         activity: {
           title: 'Tech Lead mission 4',
@@ -96,6 +97,52 @@ describe('Unit | Component | JobList.vue', () => {
             name: 'La Poste - Courrier',
           },
           staffing_needed_from: '2017-07-01',
+          duration: '10 mois',
+          location: 'OCTO',
+          business_contact: {
+            nickname: 'ABC',
+          },
+          mission_director: {
+            nickname: 'XYZ',
+          },
+        },
+      },
+      {
+        id: 5,
+        activity: {
+          title: 'Tech Lead mission 5',
+        },
+        project: {
+          id: 123456,
+          status: 'proposal_sent',
+          name: 'SCLOU - Cloud computing : enjeux, architecture et gouvernance du IaaS, CaaS, PaaS INTER 2017',
+          customer: {
+            name: 'La Poste - Courrier',
+          },
+          start_date: '2017-07-01',
+          duration: '10 mois',
+          location: 'OCTO',
+          business_contact: {
+            nickname: 'ABC',
+          },
+          mission_director: {
+            nickname: 'XYZ',
+          },
+        },
+      },
+      {
+        id: 6,
+        activity: {
+          title: 'Tech Lead mission 6',
+        },
+        project: {
+          id: 123456,
+          status: 'lead',
+          name: 'SCLOU - Cloud computing : enjeux, architecture et gouvernance du IaaS, CaaS, PaaS INTER 2017',
+          customer: {
+            name: 'La Poste - Courrier',
+          },
+          start_date: '2017-07-01',
           duration: '10 mois',
           location: 'OCTO',
           business_contact: {
@@ -132,19 +179,21 @@ describe('Unit | Component | JobList.vue', () => {
 
     it('should render as many jobs as received from the API', () => Vue.nextTick().then(() => {
       const jobCards = component.$el.querySelectorAll('.job-card');
-      expect(jobCards.length).to.equal(4);
+      expect(jobCards.length).to.equal(6);
     }));
 
     it('should add number of available jobs', () => Vue.nextTick().then(() => {
-      expect(component.$el.querySelector('.job-results__title').textContent.trim()).to.equal('Missions à staffer (4)');
+      expect(component.$el.querySelector('.job-results__title').textContent.trim()).to.equal('Missions à staffer (6)');
     }));
 
     it('should sort the mission jobs', () => Vue.nextTick().then(() => {
       const jobTitles = component.$el.querySelectorAll('.job__title');
-      expect(jobTitles[0].textContent).to.equal('Tech Lead mission 3');
-      expect(jobTitles[1].textContent).to.equal('Tech Lead mission 2');
-      expect(jobTitles[2].textContent).to.equal('Tech Lead mission 1');
+      expect(jobTitles[0].textContent).to.equal('Tech Lead mission 2');
+      expect(jobTitles[1].textContent).to.equal('Tech Lead mission 3');
+      expect(jobTitles[2].textContent).to.equal('Tech Lead mission 5');
       expect(jobTitles[3].textContent).to.equal('Tech Lead mission 4');
+      expect(jobTitles[4].textContent).to.equal('Tech Lead mission 1');
+      expect(jobTitles[5].textContent).to.equal('Tech Lead mission 6');
     }));
   });
 });

--- a/client/test/unit/specs/components/JobList.spec.js
+++ b/client/test/unit/specs/components/JobList.spec.js
@@ -2,6 +2,7 @@ import Vue from 'vue';
 import VueAnalytics from 'vue-analytics';
 import JobList from '@/components/JobList';
 import authentication from '@/services/authentication';
+import projectStatus from '@/utils/projectStatus';
 import jobsApi from '@/api/jobs';
 
 Vue.use(VueAnalytics, {
@@ -11,6 +12,7 @@ Vue.use(VueAnalytics, {
 describe('Unit | Component | JobList.vue', () => {
   let component;
   let jobs;
+  let expectedJobs;
 
   beforeEach(() => {
     // given
@@ -61,14 +63,15 @@ describe('Unit | Component | JobList.vue', () => {
           },
         },
       },
-      {
-        id: 3,
+    ];
+    expectedJobs = [  {
+        id: 2,
         activity: {
-          title: 'Tech Lead mission 3',
+          title: 'Tech Lead mission 2',
         },
         project: {
           id: 123456,
-          status: 'mission_accepted',
+          status: 'mission_signed',
           name: 'SCLOU - Cloud computing : enjeux, architecture et gouvernance du IaaS, CaaS, PaaS INTER 2017',
           customer: {
             name: 'La Poste - Courrier',
@@ -85,9 +88,9 @@ describe('Unit | Component | JobList.vue', () => {
         },
       },
       {
-        id: 4,
+        id: 1,
         activity: {
-          title: 'Tech Lead mission 4',
+          title: 'Tech Lead mission 1',
         },
         project: {
           id: 123456,
@@ -107,54 +110,9 @@ describe('Unit | Component | JobList.vue', () => {
           },
         },
       },
-      {
-        id: 5,
-        activity: {
-          title: 'Tech Lead mission 5',
-        },
-        project: {
-          id: 123456,
-          status: 'proposal_sent',
-          name: 'SCLOU - Cloud computing : enjeux, architecture et gouvernance du IaaS, CaaS, PaaS INTER 2017',
-          customer: {
-            name: 'La Poste - Courrier',
-          },
-          start_date: '2017-07-01',
-          duration: '10 mois',
-          location: 'OCTO',
-          business_contact: {
-            nickname: 'ABC',
-          },
-          mission_director: {
-            nickname: 'XYZ',
-          },
-        },
-      },
-      {
-        id: 6,
-        activity: {
-          title: 'Tech Lead mission 6',
-        },
-        project: {
-          id: 123456,
-          status: 'lead',
-          name: 'SCLOU - Cloud computing : enjeux, architecture et gouvernance du IaaS, CaaS, PaaS INTER 2017',
-          customer: {
-            name: 'La Poste - Courrier',
-          },
-          start_date: '2017-07-01',
-          duration: '10 mois',
-          location: 'OCTO',
-          business_contact: {
-            nickname: 'ABC',
-          },
-          mission_director: {
-            nickname: 'XYZ',
-          },
-        },
-      },
     ];
     sinon.stub(authentication, 'isAuthenticated').returns(true);
+    sinon.stub(projectStatus, 'sort').returns(expectedJobs);
     sinon.stub(jobsApi, 'fetchAll').resolves(jobs);
 
     const Constructor = Vue.extend(JobList);
@@ -164,6 +122,7 @@ describe('Unit | Component | JobList.vue', () => {
   });
 
   afterEach(() => {
+    projectStatus.sort.restore();
     authentication.isAuthenticated.restore();
     jobsApi.fetchAll.restore();
   });
@@ -179,21 +138,17 @@ describe('Unit | Component | JobList.vue', () => {
 
     it('should render as many jobs as received from the API', () => Vue.nextTick().then(() => {
       const jobCards = component.$el.querySelectorAll('.job-card');
-      expect(jobCards.length).to.equal(6);
+      expect(jobCards.length).to.equal(2);
     }));
 
     it('should add number of available jobs', () => Vue.nextTick().then(() => {
-      expect(component.$el.querySelector('.job-results__title').textContent.trim()).to.equal('Missions à staffer (6)');
+      expect(component.$el.querySelector('.job-results__title').textContent.trim()).to.equal('Missions à staffer (2)');
     }));
 
     it('should sort the mission jobs', () => Vue.nextTick().then(() => {
       const jobTitles = component.$el.querySelectorAll('.job__title');
       expect(jobTitles[0].textContent).to.equal('Tech Lead mission 2');
-      expect(jobTitles[1].textContent).to.equal('Tech Lead mission 3');
-      expect(jobTitles[2].textContent).to.equal('Tech Lead mission 5');
-      expect(jobTitles[3].textContent).to.equal('Tech Lead mission 4');
-      expect(jobTitles[4].textContent).to.equal('Tech Lead mission 1');
-      expect(jobTitles[5].textContent).to.equal('Tech Lead mission 6');
+      expect(jobTitles[1].textContent).to.equal('Tech Lead mission 1');
     }));
   });
 });

--- a/client/test/unit/specs/components/JobList.spec.js
+++ b/client/test/unit/specs/components/JobList.spec.js
@@ -66,51 +66,51 @@ describe('Unit | Component | JobList.vue', () => {
     ];
     expectedJobs = [{
 
-          id: 2,
-          activity: {
-            title: 'Tech Lead mission 2',
-          },
-          project: {
-            id: 123456,
-            status: 'mission_signed',
-            name: 'SCLOU - Cloud computing : enjeux, architecture et gouvernance du IaaS, CaaS, PaaS INTER 2017',
-            customer: {
-              name: 'La Poste - Courrier',
-            },
-            staffing_needed_from: '2017-07-01',
-            duration: '10 mois',
-            location: 'OCTO',
-            business_contact: {
-              nickname: 'ABC',
-            },
-            mission_director: {
-              nickname: 'XYZ',
-            },
-          },
+      id: 2,
+      activity: {
+        title: 'Tech Lead mission 2',
+      },
+      project: {
+        id: 123456,
+        status: 'mission_signed',
+        name: 'SCLOU - Cloud computing : enjeux, architecture et gouvernance du IaaS, CaaS, PaaS INTER 2017',
+        customer: {
+          name: 'La Poste - Courrier',
         },
-      {
-        id: 1,
-        activity: {
-          title: 'Tech Lead mission 1',
+        staffing_needed_from: '2017-07-01',
+        duration: '10 mois',
+        location: 'OCTO',
+        business_contact: {
+          nickname: 'ABC',
         },
-        project: {
-          id: 123456,
-          status: 'proposal_in_progress',
-          name: 'SCLOU - Cloud computing : enjeux, architecture et gouvernance du IaaS, CaaS, PaaS INTER 2017',
-          customer: {
-            name: 'La Poste - Courrier',
-          },
-          staffing_needed_from: '2017-07-01',
-          duration: '10 mois',
-          location: 'OCTO',
-          business_contact: {
-            nickname: 'ABC',
-          },
-          mission_director: {
-            nickname: 'XYZ',
-          },
+        mission_director: {
+          nickname: 'XYZ',
         },
       },
+    },
+    {
+      id: 1,
+      activity: {
+        title: 'Tech Lead mission 1',
+      },
+      project: {
+        id: 123456,
+        status: 'proposal_in_progress',
+        name: 'SCLOU - Cloud computing : enjeux, architecture et gouvernance du IaaS, CaaS, PaaS INTER 2017',
+        customer: {
+          name: 'La Poste - Courrier',
+        },
+        staffing_needed_from: '2017-07-01',
+        duration: '10 mois',
+        location: 'OCTO',
+        business_contact: {
+          nickname: 'ABC',
+        },
+        mission_director: {
+          nickname: 'XYZ',
+        },
+      },
+    },
     ];
     sinon.stub(authentication, 'isAuthenticated').returns(true);
     sinon.stub(projectStatus, 'sort').returns(expectedJobs);

--- a/client/test/unit/specs/components/JobList.spec.js
+++ b/client/test/unit/specs/components/JobList.spec.js
@@ -83,7 +83,7 @@ describe('Unit | Component | JobList.vue', () => {
             nickname: 'XYZ',
           },
         },
-      },{
+      }, {
         id: 4,
         activity: {
           title: 'Tech Lead mission 4',
@@ -105,7 +105,7 @@ describe('Unit | Component | JobList.vue', () => {
             nickname: 'XYZ',
           },
         },
-      }
+      },
     ];
     sinon.stub(authentication, 'isAuthenticated').returns(true);
     sinon.stub(jobsApi, 'fetchAll').resolves(jobs);
@@ -140,7 +140,7 @@ describe('Unit | Component | JobList.vue', () => {
     }));
 
     it('should sort the mission jobs', () => Vue.nextTick().then(() => {
-      const jobTitles = component.$el.querySelectorAll('.job__title')
+      const jobTitles = component.$el.querySelectorAll('.job__title');
       expect(jobTitles[0].textContent).to.equal('Tech Lead mission 3');
       expect(jobTitles[1].textContent).to.equal('Tech Lead mission 2');
       expect(jobTitles[2].textContent).to.equal('Tech Lead mission 1');

--- a/client/test/unit/specs/components/JobList.spec.js
+++ b/client/test/unit/specs/components/JobList.spec.js
@@ -64,29 +64,30 @@ describe('Unit | Component | JobList.vue', () => {
         },
       },
     ];
-    expectedJobs = [  {
-        id: 2,
-        activity: {
-          title: 'Tech Lead mission 2',
+    expectedJobs = [{
+
+          id: 2,
+          activity: {
+            title: 'Tech Lead mission 2',
+          },
+          project: {
+            id: 123456,
+            status: 'mission_signed',
+            name: 'SCLOU - Cloud computing : enjeux, architecture et gouvernance du IaaS, CaaS, PaaS INTER 2017',
+            customer: {
+              name: 'La Poste - Courrier',
+            },
+            staffing_needed_from: '2017-07-01',
+            duration: '10 mois',
+            location: 'OCTO',
+            business_contact: {
+              nickname: 'ABC',
+            },
+            mission_director: {
+              nickname: 'XYZ',
+            },
+          },
         },
-        project: {
-          id: 123456,
-          status: 'mission_signed',
-          name: 'SCLOU - Cloud computing : enjeux, architecture et gouvernance du IaaS, CaaS, PaaS INTER 2017',
-          customer: {
-            name: 'La Poste - Courrier',
-          },
-          staffing_needed_from: '2017-07-01',
-          duration: '10 mois',
-          location: 'OCTO',
-          business_contact: {
-            nickname: 'ABC',
-          },
-          mission_director: {
-            nickname: 'XYZ',
-          },
-        },
-      },
       {
         id: 1,
         activity: {

--- a/client/test/unit/specs/components/JobList.spec.js
+++ b/client/test/unit/specs/components/JobList.spec.js
@@ -14,29 +14,99 @@ describe('Unit | Component | JobList.vue', () => {
 
   beforeEach(() => {
     // given
-    jobs = [{
-      id: 2,
-      activity: {
-        title: 'Tech Lead',
+    jobs = [
+      {
+        id: 1,
+        activity: {
+          title: 'Tech Lead mission 1',
+        },
+        project: {
+          id: 123456,
+          status: 'proposal_in_progress',
+          name: 'SCLOU - Cloud computing : enjeux, architecture et gouvernance du IaaS, CaaS, PaaS INTER 2017',
+          customer: {
+            name: 'La Poste - Courrier',
+          },
+          staffing_needed_from: '2017-07-01',
+          duration: '10 mois',
+          location: 'OCTO',
+          business_contact: {
+            nickname: 'ABC',
+          },
+          mission_director: {
+            nickname: 'XYZ',
+          },
+        },
       },
-      project: {
-        id: 123456,
-        status: 'proposal-in-progress',
-        name: 'SCLOU - Cloud computing : enjeux, architecture et gouvernance du IaaS, CaaS, PaaS INTER 2017',
-        customer: {
-          name: 'La Poste - Courrier',
+      {
+        id: 2,
+        activity: {
+          title: 'Tech Lead mission 2',
         },
-        staffing_needed_from: '2017-07-01',
-        duration: '10 mois',
-        location: 'OCTO',
-        business_contact: {
-          nickname: 'ABC',
-        },
-        mission_director: {
-          nickname: 'XYZ',
+        project: {
+          id: 123456,
+          status: 'mission_signed',
+          name: 'SCLOU - Cloud computing : enjeux, architecture et gouvernance du IaaS, CaaS, PaaS INTER 2017',
+          customer: {
+            name: 'La Poste - Courrier',
+          },
+          staffing_needed_from: '2017-07-01',
+          duration: '10 mois',
+          location: 'OCTO',
+          business_contact: {
+            nickname: 'ABC',
+          },
+          mission_director: {
+            nickname: 'XYZ',
+          },
         },
       },
-    }];
+      {
+        id: 3,
+        activity: {
+          title: 'Tech Lead mission 3',
+        },
+        project: {
+          id: 123456,
+          status: 'mission_accepted',
+          name: 'SCLOU - Cloud computing : enjeux, architecture et gouvernance du IaaS, CaaS, PaaS INTER 2017',
+          customer: {
+            name: 'La Poste - Courrier',
+          },
+          staffing_needed_from: '2017-07-01',
+          duration: '10 mois',
+          location: 'OCTO',
+          business_contact: {
+            nickname: 'ABC',
+          },
+          mission_director: {
+            nickname: 'XYZ',
+          },
+        },
+      },{
+        id: 4,
+        activity: {
+          title: 'Tech Lead mission 4',
+        },
+        project: {
+          id: 123456,
+          status: 'proposal_in_progress',
+          name: 'SCLOU - Cloud computing : enjeux, architecture et gouvernance du IaaS, CaaS, PaaS INTER 2017',
+          customer: {
+            name: 'La Poste - Courrier',
+          },
+          staffing_needed_from: '2017-07-01',
+          duration: '10 mois',
+          location: 'OCTO',
+          business_contact: {
+            nickname: 'ABC',
+          },
+          mission_director: {
+            nickname: 'XYZ',
+          },
+        },
+      }
+    ];
     sinon.stub(authentication, 'isAuthenticated').returns(true);
     sinon.stub(jobsApi, 'fetchAll').resolves(jobs);
 
@@ -62,11 +132,19 @@ describe('Unit | Component | JobList.vue', () => {
 
     it('should render as many jobs as received from the API', () => Vue.nextTick().then(() => {
       const jobCards = component.$el.querySelectorAll('.job-card');
-      expect(jobCards.length).to.equal(1);
+      expect(jobCards.length).to.equal(4);
     }));
 
     it('should add number of available jobs', () => Vue.nextTick().then(() => {
-      expect(component.$el.querySelector('.job-results__title').textContent.trim()).to.equal('Missions à staffer (1)');
+      expect(component.$el.querySelector('.job-results__title').textContent.trim()).to.equal('Missions à staffer (4)');
+    }));
+
+    it('should sort the mission jobs', () => Vue.nextTick().then(() => {
+      const jobTitles = component.$el.querySelectorAll('.job__title')
+      expect(jobTitles[0].textContent).to.equal('Tech Lead mission 3');
+      expect(jobTitles[1].textContent).to.equal('Tech Lead mission 2');
+      expect(jobTitles[2].textContent).to.equal('Tech Lead mission 1');
+      expect(jobTitles[3].textContent).to.equal('Tech Lead mission 4');
     }));
   });
 });

--- a/client/test/unit/specs/utils/projectStatus.spec.js
+++ b/client/test/unit/specs/utils/projectStatus.spec.js
@@ -1,295 +1,294 @@
 import projectStatus from '@/utils/projectStatus';
 
 describe('Unit | Utils | Project Status', () => {
-    it('should sort jobs according to project status', () => {
-      // Given
-      let jobs = [
-        {
-          id: 1,
-          activity: {
-            title: 'Tech Lead mission 1',
+  it('should sort jobs according to project status', () => {
+    // Given
+    const jobs = [
+      {
+        id: 1,
+        activity: {
+          title: 'Tech Lead mission 1',
+        },
+        project: {
+          id: 123456,
+          status: 'proposal_in_progress',
+          name: 'SCLOU - Cloud computing : enjeux, architecture et gouvernance du IaaS, CaaS, PaaS INTER 2017',
+          customer: {
+            name: 'La Poste - Courrier',
           },
-          project: {
-            id: 123456,
-            status: 'proposal_in_progress',
-            name: 'SCLOU - Cloud computing : enjeux, architecture et gouvernance du IaaS, CaaS, PaaS INTER 2017',
-            customer: {
-              name: 'La Poste - Courrier',
-            },
-            start_date: '2017-07-01',
-            duration: '10 mois',
-            location: 'OCTO',
-            business_contact: {
-              nickname: 'ABC',
-            },
-            mission_director: {
-              nickname: 'XYZ',
-            },
+          start_date: '2017-07-01',
+          duration: '10 mois',
+          location: 'OCTO',
+          business_contact: {
+            nickname: 'ABC',
+          },
+          mission_director: {
+            nickname: 'XYZ',
           },
         },
-        {
-          id: 2,
-          activity: {
-            title: 'Tech Lead mission 2',
+      },
+      {
+        id: 2,
+        activity: {
+          title: 'Tech Lead mission 2',
+        },
+        project: {
+          id: 123456,
+          status: 'mission_signed',
+          name: 'SCLOU - Cloud computing : enjeux, architecture et gouvernance du IaaS, CaaS, PaaS INTER 2017',
+          customer: {
+            name: 'La Poste - Courrier',
           },
-          project: {
-            id: 123456,
-            status: 'mission_signed',
-            name: 'SCLOU - Cloud computing : enjeux, architecture et gouvernance du IaaS, CaaS, PaaS INTER 2017',
-            customer: {
-              name: 'La Poste - Courrier',
-            },
-            start_date: '2017-07-01',
-            duration: '10 mois',
-            location: 'OCTO',
-            business_contact: {
-              nickname: 'ABC',
-            },
-            mission_director: {
-              nickname: 'XYZ',
-            },
+          start_date: '2017-07-01',
+          duration: '10 mois',
+          location: 'OCTO',
+          business_contact: {
+            nickname: 'ABC',
+          },
+          mission_director: {
+            nickname: 'XYZ',
           },
         },
-        {
-          id: 3,
-          activity: {
-            title: 'Tech Lead mission 3',
+      },
+      {
+        id: 3,
+        activity: {
+          title: 'Tech Lead mission 3',
+        },
+        project: {
+          id: 123456,
+          status: 'mission_accepted',
+          name: 'SCLOU - Cloud computing : enjeux, architecture et gouvernance du IaaS, CaaS, PaaS INTER 2017',
+          customer: {
+            name: 'La Poste - Courrier',
           },
-          project: {
-            id: 123456,
-            status: 'mission_accepted',
-            name: 'SCLOU - Cloud computing : enjeux, architecture et gouvernance du IaaS, CaaS, PaaS INTER 2017',
-            customer: {
-              name: 'La Poste - Courrier',
-            },
-            start_date: '2017-07-01',
-            duration: '10 mois',
-            location: 'OCTO',
-            business_contact: {
-              nickname: 'ABC',
-            },
-            mission_director: {
-              nickname: 'XYZ',
-            },
+          start_date: '2017-07-01',
+          duration: '10 mois',
+          location: 'OCTO',
+          business_contact: {
+            nickname: 'ABC',
+          },
+          mission_director: {
+            nickname: 'XYZ',
           },
         },
-        {
-          id: 4,
-          activity: {
-            title: 'Tech Lead mission 4',
+      },
+      {
+        id: 4,
+        activity: {
+          title: 'Tech Lead mission 4',
+        },
+        project: {
+          id: 123456,
+          status: 'proposal_in_progress',
+          name: 'SCLOU - Cloud computing : enjeux, architecture et gouvernance du IaaS, CaaS, PaaS INTER 2017',
+          customer: {
+            name: 'La Poste - Courrier',
           },
-          project: {
-            id: 123456,
-            status: 'proposal_in_progress',
-            name: 'SCLOU - Cloud computing : enjeux, architecture et gouvernance du IaaS, CaaS, PaaS INTER 2017',
-            customer: {
-              name: 'La Poste - Courrier',
-            },
-            start_date: '2017-07-01',
-            duration: '10 mois',
-            location: 'OCTO',
-            business_contact: {
-              nickname: 'ABC',
-            },
-            mission_director: {
-              nickname: 'XYZ',
-            },
+          start_date: '2017-07-01',
+          duration: '10 mois',
+          location: 'OCTO',
+          business_contact: {
+            nickname: 'ABC',
+          },
+          mission_director: {
+            nickname: 'XYZ',
           },
         },
-        {
-          id: 5,
-          activity: {
-            title: 'Tech Lead mission 5',
+      },
+      {
+        id: 5,
+        activity: {
+          title: 'Tech Lead mission 5',
+        },
+        project: {
+          id: 123456,
+          status: 'proposal_sent',
+          name: 'SCLOU - Cloud computing : enjeux, architecture et gouvernance du IaaS, CaaS, PaaS INTER 2017',
+          customer: {
+            name: 'La Poste - Courrier',
           },
-          project: {
-            id: 123456,
-            status: 'proposal_sent',
-            name: 'SCLOU - Cloud computing : enjeux, architecture et gouvernance du IaaS, CaaS, PaaS INTER 2017',
-            customer: {
-              name: 'La Poste - Courrier',
-            },
-            start_date: '2017-07-01',
-            duration: '10 mois',
-            location: 'OCTO',
-            business_contact: {
-              nickname: 'ABC',
-            },
-            mission_director: {
-              nickname: 'XYZ',
-            },
+          start_date: '2017-07-01',
+          duration: '10 mois',
+          location: 'OCTO',
+          business_contact: {
+            nickname: 'ABC',
+          },
+          mission_director: {
+            nickname: 'XYZ',
           },
         },
-        {
-          id: 6,
-          activity: {
-            title: 'Tech Lead mission 6',
+      },
+      {
+        id: 6,
+        activity: {
+          title: 'Tech Lead mission 6',
+        },
+        project: {
+          id: 123456,
+          status: 'lead',
+          name: 'SCLOU - Cloud computing : enjeux, architecture et gouvernance du IaaS, CaaS, PaaS INTER 2017',
+          customer: {
+            name: 'La Poste - Courrier',
           },
-          project: {
-            id: 123456,
-            status: 'lead',
-            name: 'SCLOU - Cloud computing : enjeux, architecture et gouvernance du IaaS, CaaS, PaaS INTER 2017',
-            customer: {
-              name: 'La Poste - Courrier',
-            },
-            start_date: '2017-07-01',
-            duration: '10 mois',
-            location: 'OCTO',
-            business_contact: {
-              nickname: 'ABC',
-            },
-            mission_director: {
-              nickname: 'XYZ',
-            },
+          start_date: '2017-07-01',
+          duration: '10 mois',
+          location: 'OCTO',
+          business_contact: {
+            nickname: 'ABC',
+          },
+          mission_director: {
+            nickname: 'XYZ',
           },
         },
-      ];
+      },
+    ];
 
-      // When
-      const sortedJobs = projectStatus.sort(jobs)
+    // When
+    const sortedJobs = projectStatus.sort(jobs);
 
-      // Then
-      let expectedJobs = [
-        {
-          id: 2,
-          activity: {
-            title: 'Tech Lead mission 2',
+    // Then
+    const expectedJobs = [
+      {
+        id: 2,
+        activity: {
+          title: 'Tech Lead mission 2',
+        },
+        project: {
+          id: 123456,
+          status: 'mission_signed',
+          name: 'SCLOU - Cloud computing : enjeux, architecture et gouvernance du IaaS, CaaS, PaaS INTER 2017',
+          customer: {
+            name: 'La Poste - Courrier',
           },
-          project: {
-            id: 123456,
-            status: 'mission_signed',
-            name: 'SCLOU - Cloud computing : enjeux, architecture et gouvernance du IaaS, CaaS, PaaS INTER 2017',
-            customer: {
-              name: 'La Poste - Courrier',
-            },
-            start_date: '2017-07-01',
-            duration: '10 mois',
-            location: 'OCTO',
-            business_contact: {
-              nickname: 'ABC',
-            },
-            mission_director: {
-              nickname: 'XYZ',
-            },
+          start_date: '2017-07-01',
+          duration: '10 mois',
+          location: 'OCTO',
+          business_contact: {
+            nickname: 'ABC',
+          },
+          mission_director: {
+            nickname: 'XYZ',
           },
         },
-        {
-          id: 3,
-          activity: {
-            title: 'Tech Lead mission 3',
+      },
+      {
+        id: 3,
+        activity: {
+          title: 'Tech Lead mission 3',
+        },
+        project: {
+          id: 123456,
+          status: 'mission_accepted',
+          name: 'SCLOU - Cloud computing : enjeux, architecture et gouvernance du IaaS, CaaS, PaaS INTER 2017',
+          customer: {
+            name: 'La Poste - Courrier',
           },
-          project: {
-            id: 123456,
-            status: 'mission_accepted',
-            name: 'SCLOU - Cloud computing : enjeux, architecture et gouvernance du IaaS, CaaS, PaaS INTER 2017',
-            customer: {
-              name: 'La Poste - Courrier',
-            },
-            start_date: '2017-07-01',
-            duration: '10 mois',
-            location: 'OCTO',
-            business_contact: {
-              nickname: 'ABC',
-            },
-            mission_director: {
-              nickname: 'XYZ',
-            },
+          start_date: '2017-07-01',
+          duration: '10 mois',
+          location: 'OCTO',
+          business_contact: {
+            nickname: 'ABC',
+          },
+          mission_director: {
+            nickname: 'XYZ',
           },
         },
-        {
-          id: 5,
-          activity: {
-            title: 'Tech Lead mission 5',
+      },
+      {
+        id: 5,
+        activity: {
+          title: 'Tech Lead mission 5',
+        },
+        project: {
+          id: 123456,
+          status: 'proposal_sent',
+          name: 'SCLOU - Cloud computing : enjeux, architecture et gouvernance du IaaS, CaaS, PaaS INTER 2017',
+          customer: {
+            name: 'La Poste - Courrier',
           },
-          project: {
-            id: 123456,
-            status: 'proposal_sent',
-            name: 'SCLOU - Cloud computing : enjeux, architecture et gouvernance du IaaS, CaaS, PaaS INTER 2017',
-            customer: {
-              name: 'La Poste - Courrier',
-            },
-            start_date: '2017-07-01',
-            duration: '10 mois',
-            location: 'OCTO',
-            business_contact: {
-              nickname: 'ABC',
-            },
-            mission_director: {
-              nickname: 'XYZ',
-            },
+          start_date: '2017-07-01',
+          duration: '10 mois',
+          location: 'OCTO',
+          business_contact: {
+            nickname: 'ABC',
+          },
+          mission_director: {
+            nickname: 'XYZ',
           },
         },
-        {
-          id: 4,
-          activity: {
-            title: 'Tech Lead mission 4',
+      },
+      {
+        id: 4,
+        activity: {
+          title: 'Tech Lead mission 4',
+        },
+        project: {
+          id: 123456,
+          status: 'proposal_in_progress',
+          name: 'SCLOU - Cloud computing : enjeux, architecture et gouvernance du IaaS, CaaS, PaaS INTER 2017',
+          customer: {
+            name: 'La Poste - Courrier',
           },
-          project: {
-            id: 123456,
-            status: 'proposal_in_progress',
-            name: 'SCLOU - Cloud computing : enjeux, architecture et gouvernance du IaaS, CaaS, PaaS INTER 2017',
-            customer: {
-              name: 'La Poste - Courrier',
-            },
-            start_date: '2017-07-01',
-            duration: '10 mois',
-            location: 'OCTO',
-            business_contact: {
-              nickname: 'ABC',
-            },
-            mission_director: {
-              nickname: 'XYZ',
-            },
+          start_date: '2017-07-01',
+          duration: '10 mois',
+          location: 'OCTO',
+          business_contact: {
+            nickname: 'ABC',
+          },
+          mission_director: {
+            nickname: 'XYZ',
           },
         },
-        {
-          id: 1,
-          activity: {
-            title: 'Tech Lead mission 1',
+      },
+      {
+        id: 1,
+        activity: {
+          title: 'Tech Lead mission 1',
+        },
+        project: {
+          id: 123456,
+          status: 'proposal_in_progress',
+          name: 'SCLOU - Cloud computing : enjeux, architecture et gouvernance du IaaS, CaaS, PaaS INTER 2017',
+          customer: {
+            name: 'La Poste - Courrier',
           },
-          project: {
-            id: 123456,
-            status: 'proposal_in_progress',
-            name: 'SCLOU - Cloud computing : enjeux, architecture et gouvernance du IaaS, CaaS, PaaS INTER 2017',
-            customer: {
-              name: 'La Poste - Courrier',
-            },
-            start_date: '2017-07-01',
-            duration: '10 mois',
-            location: 'OCTO',
-            business_contact: {
-              nickname: 'ABC',
-            },
-            mission_director: {
-              nickname: 'XYZ',
-            },
+          start_date: '2017-07-01',
+          duration: '10 mois',
+          location: 'OCTO',
+          business_contact: {
+            nickname: 'ABC',
+          },
+          mission_director: {
+            nickname: 'XYZ',
           },
         },
-        {
-          id: 6,
-          activity: {
-            title: 'Tech Lead mission 6',
+      },
+      {
+        id: 6,
+        activity: {
+          title: 'Tech Lead mission 6',
+        },
+        project: {
+          id: 123456,
+          status: 'lead',
+          name: 'SCLOU - Cloud computing : enjeux, architecture et gouvernance du IaaS, CaaS, PaaS INTER 2017',
+          customer: {
+            name: 'La Poste - Courrier',
           },
-          project: {
-            id: 123456,
-            status: 'lead',
-            name: 'SCLOU - Cloud computing : enjeux, architecture et gouvernance du IaaS, CaaS, PaaS INTER 2017',
-            customer: {
-              name: 'La Poste - Courrier',
-            },
-            start_date: '2017-07-01',
-            duration: '10 mois',
-            location: 'OCTO',
-            business_contact: {
-              nickname: 'ABC',
-            },
-            mission_director: {
-              nickname: 'XYZ',
-            },
+          start_date: '2017-07-01',
+          duration: '10 mois',
+          location: 'OCTO',
+          business_contact: {
+            nickname: 'ABC',
+          },
+          mission_director: {
+            nickname: 'XYZ',
           },
         },
-      ];
-      expect(sortedJobs).to.deep.equal(expectedJobs)
-
-    })
+      },
+    ];
+    expect(sortedJobs).to.deep.equal(expectedJobs);
+  });
 });
 

--- a/client/test/unit/specs/utils/projectStatus.spec.js
+++ b/client/test/unit/specs/utils/projectStatus.spec.js
@@ -1,0 +1,295 @@
+import projectStatus from '@/utils/projectStatus';
+
+describe('Unit | Utils | Project Status', () => {
+    it('should sort jobs according to project status', () => {
+      // Given
+      let jobs = [
+        {
+          id: 1,
+          activity: {
+            title: 'Tech Lead mission 1',
+          },
+          project: {
+            id: 123456,
+            status: 'proposal_in_progress',
+            name: 'SCLOU - Cloud computing : enjeux, architecture et gouvernance du IaaS, CaaS, PaaS INTER 2017',
+            customer: {
+              name: 'La Poste - Courrier',
+            },
+            start_date: '2017-07-01',
+            duration: '10 mois',
+            location: 'OCTO',
+            business_contact: {
+              nickname: 'ABC',
+            },
+            mission_director: {
+              nickname: 'XYZ',
+            },
+          },
+        },
+        {
+          id: 2,
+          activity: {
+            title: 'Tech Lead mission 2',
+          },
+          project: {
+            id: 123456,
+            status: 'mission_signed',
+            name: 'SCLOU - Cloud computing : enjeux, architecture et gouvernance du IaaS, CaaS, PaaS INTER 2017',
+            customer: {
+              name: 'La Poste - Courrier',
+            },
+            start_date: '2017-07-01',
+            duration: '10 mois',
+            location: 'OCTO',
+            business_contact: {
+              nickname: 'ABC',
+            },
+            mission_director: {
+              nickname: 'XYZ',
+            },
+          },
+        },
+        {
+          id: 3,
+          activity: {
+            title: 'Tech Lead mission 3',
+          },
+          project: {
+            id: 123456,
+            status: 'mission_accepted',
+            name: 'SCLOU - Cloud computing : enjeux, architecture et gouvernance du IaaS, CaaS, PaaS INTER 2017',
+            customer: {
+              name: 'La Poste - Courrier',
+            },
+            start_date: '2017-07-01',
+            duration: '10 mois',
+            location: 'OCTO',
+            business_contact: {
+              nickname: 'ABC',
+            },
+            mission_director: {
+              nickname: 'XYZ',
+            },
+          },
+        },
+        {
+          id: 4,
+          activity: {
+            title: 'Tech Lead mission 4',
+          },
+          project: {
+            id: 123456,
+            status: 'proposal_in_progress',
+            name: 'SCLOU - Cloud computing : enjeux, architecture et gouvernance du IaaS, CaaS, PaaS INTER 2017',
+            customer: {
+              name: 'La Poste - Courrier',
+            },
+            start_date: '2017-07-01',
+            duration: '10 mois',
+            location: 'OCTO',
+            business_contact: {
+              nickname: 'ABC',
+            },
+            mission_director: {
+              nickname: 'XYZ',
+            },
+          },
+        },
+        {
+          id: 5,
+          activity: {
+            title: 'Tech Lead mission 5',
+          },
+          project: {
+            id: 123456,
+            status: 'proposal_sent',
+            name: 'SCLOU - Cloud computing : enjeux, architecture et gouvernance du IaaS, CaaS, PaaS INTER 2017',
+            customer: {
+              name: 'La Poste - Courrier',
+            },
+            start_date: '2017-07-01',
+            duration: '10 mois',
+            location: 'OCTO',
+            business_contact: {
+              nickname: 'ABC',
+            },
+            mission_director: {
+              nickname: 'XYZ',
+            },
+          },
+        },
+        {
+          id: 6,
+          activity: {
+            title: 'Tech Lead mission 6',
+          },
+          project: {
+            id: 123456,
+            status: 'lead',
+            name: 'SCLOU - Cloud computing : enjeux, architecture et gouvernance du IaaS, CaaS, PaaS INTER 2017',
+            customer: {
+              name: 'La Poste - Courrier',
+            },
+            start_date: '2017-07-01',
+            duration: '10 mois',
+            location: 'OCTO',
+            business_contact: {
+              nickname: 'ABC',
+            },
+            mission_director: {
+              nickname: 'XYZ',
+            },
+          },
+        },
+      ];
+
+      // When
+      const sortedJobs = projectStatus.sort(jobs)
+
+      // Then
+      let expectedJobs = [
+        {
+          id: 2,
+          activity: {
+            title: 'Tech Lead mission 2',
+          },
+          project: {
+            id: 123456,
+            status: 'mission_signed',
+            name: 'SCLOU - Cloud computing : enjeux, architecture et gouvernance du IaaS, CaaS, PaaS INTER 2017',
+            customer: {
+              name: 'La Poste - Courrier',
+            },
+            start_date: '2017-07-01',
+            duration: '10 mois',
+            location: 'OCTO',
+            business_contact: {
+              nickname: 'ABC',
+            },
+            mission_director: {
+              nickname: 'XYZ',
+            },
+          },
+        },
+        {
+          id: 3,
+          activity: {
+            title: 'Tech Lead mission 3',
+          },
+          project: {
+            id: 123456,
+            status: 'mission_accepted',
+            name: 'SCLOU - Cloud computing : enjeux, architecture et gouvernance du IaaS, CaaS, PaaS INTER 2017',
+            customer: {
+              name: 'La Poste - Courrier',
+            },
+            start_date: '2017-07-01',
+            duration: '10 mois',
+            location: 'OCTO',
+            business_contact: {
+              nickname: 'ABC',
+            },
+            mission_director: {
+              nickname: 'XYZ',
+            },
+          },
+        },
+        {
+          id: 5,
+          activity: {
+            title: 'Tech Lead mission 5',
+          },
+          project: {
+            id: 123456,
+            status: 'proposal_sent',
+            name: 'SCLOU - Cloud computing : enjeux, architecture et gouvernance du IaaS, CaaS, PaaS INTER 2017',
+            customer: {
+              name: 'La Poste - Courrier',
+            },
+            start_date: '2017-07-01',
+            duration: '10 mois',
+            location: 'OCTO',
+            business_contact: {
+              nickname: 'ABC',
+            },
+            mission_director: {
+              nickname: 'XYZ',
+            },
+          },
+        },
+        {
+          id: 4,
+          activity: {
+            title: 'Tech Lead mission 4',
+          },
+          project: {
+            id: 123456,
+            status: 'proposal_in_progress',
+            name: 'SCLOU - Cloud computing : enjeux, architecture et gouvernance du IaaS, CaaS, PaaS INTER 2017',
+            customer: {
+              name: 'La Poste - Courrier',
+            },
+            start_date: '2017-07-01',
+            duration: '10 mois',
+            location: 'OCTO',
+            business_contact: {
+              nickname: 'ABC',
+            },
+            mission_director: {
+              nickname: 'XYZ',
+            },
+          },
+        },
+        {
+          id: 1,
+          activity: {
+            title: 'Tech Lead mission 1',
+          },
+          project: {
+            id: 123456,
+            status: 'proposal_in_progress',
+            name: 'SCLOU - Cloud computing : enjeux, architecture et gouvernance du IaaS, CaaS, PaaS INTER 2017',
+            customer: {
+              name: 'La Poste - Courrier',
+            },
+            start_date: '2017-07-01',
+            duration: '10 mois',
+            location: 'OCTO',
+            business_contact: {
+              nickname: 'ABC',
+            },
+            mission_director: {
+              nickname: 'XYZ',
+            },
+          },
+        },
+        {
+          id: 6,
+          activity: {
+            title: 'Tech Lead mission 6',
+          },
+          project: {
+            id: 123456,
+            status: 'lead',
+            name: 'SCLOU - Cloud computing : enjeux, architecture et gouvernance du IaaS, CaaS, PaaS INTER 2017',
+            customer: {
+              name: 'La Poste - Courrier',
+            },
+            start_date: '2017-07-01',
+            duration: '10 mois',
+            location: 'OCTO',
+            business_contact: {
+              nickname: 'ABC',
+            },
+            mission_director: {
+              nickname: 'XYZ',
+            },
+          },
+        },
+      ];
+      expect(sortedJobs).to.deep.equal(expectedJobs)
+
+    })
+});
+


### PR DESCRIPTION
L'objectif de cette PR  est distinguer les missions des propales, et également d'apporter un tri dans l'ordre d'affichage des missions.

J'ai conservé les couleurs d'Octopod pour distinguer les missions accepted des missions signed, idem au niveau des proposal sent vs proposal in progress vs lead.

https://github.com/octo-web-front-end-tribe/octo-job-board/issues/65

<img width="1404" alt="capture d ecran 2017-07-17 a 19 58 33" src="https://user-images.githubusercontent.com/8363334/28282333-5922b906-6b2a-11e7-81ed-de2310f55bc7.png">
