### PR TITLE
Tech: add prepush in order to not push code with test failed or lint errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "lint": "npm run lint:client && npm run lint:server",
     "lint:fix": "(cd client && npm run lint:fix) && (cd server && npm run lint:fix)",
     "release": "./tools/release/release.sh",
-    "heroku-postbuild": "npm run build"
+    "heroku-postbuild": "npm run build",
+    "prepush": "npm run lint:fix && npm test"
   },
   "repository": {
     "type": "git",
@@ -37,6 +38,7 @@
   },
   "homepage": "https://github.com/octo-web-front-end-tribe/octo-job-board#readme",
   "devDependencies": {
+    "husky": "^0.14.3",
     "nodemon": "^1.11.0"
   }
 }


### PR DESCRIPTION
On a tous besoin d'un husky dans sa cyber vie !

Hook sur le prepush pour éviter de pousser des tests qui fails et du lint en erreur